### PR TITLE
VS Code の textlint 拡張を新しいものに移行する

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "ms-vscode-remote.remote-containers",
     "streetsidesoftware.code-spell-checker",
-    "taichi.vscode-textlint",
+    "3w36zj6.textlint",
     "esbenp.prettier-vscode"
   ],
 }


### PR DESCRIPTION
[taichi.vscode-textlint](https://marketplace.visualstudio.com/items/?itemName=taichi.vscode-textlint) 拡張は非推奨となり、[3w36zj6.textlint](https://marketplace.visualstudio.com/items/?itemName=3w36zj6.textlint) 拡張への移行が推奨されています。

どちらもソースは https://github.com/textlint/vscode-textlint です。リリース担当者が交代したことによって Marketplace 上の識別子が変わったようです。

古いものはバージョン 0.10.0 で止まっていますが、新しいものは更新されてバージョンが進んでいます。